### PR TITLE
Share base url

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,7 @@ npm install
 ```sh
 npm run dev
 ```
+
+# Extension
+## Caveats
+Our API's base URL must be part of the `permissions` in `manifest.json`. However, we haven't mapped that to what's in `.env`, so must be updated manually.

--- a/manifest.json
+++ b/manifest.json
@@ -15,6 +15,6 @@
   ],
 
   "permissions": [
-    "https://6e9d-2600-1700-5b24-a090-dcd4-affe-ad06-55fd.ngrok-free.app/*"
+    "https://282e-2600-1700-5b24-a090-211f-4802-68b7-33a5.ngrok-free.app/*"
   ]
 }

--- a/src/api-client.js
+++ b/src/api-client.js
@@ -1,0 +1,3 @@
+const LOCAL_BASE_URL = "https://localhost:3000";
+
+export const BASE_URL = import.meta.env.VITE_OUR_BASE_URL ?? LOCAL_BASE_URL;

--- a/src/demo-reviews.js
+++ b/src/demo-reviews.js
@@ -38,4 +38,6 @@ async function loadReviews() {
 loadReviews().then(console.log).catch(console.error);
 
 console.log("Context menu will appear on click - Reviews Everywhere");
+
+// TODO: Move this into another file, process, build?? IDK??
 document.addEventListener("click", onDocumentClick);

--- a/src/demo-reviews.js
+++ b/src/demo-reviews.js
@@ -1,5 +1,6 @@
 import van from "vanjs-core";
 
+import { BASE_URL } from "./api-client";
 import { OverlayReview } from "./review";
 import { onDocumentClick } from "./reviews-everywhere";
 
@@ -8,9 +9,6 @@ import { onDocumentClick } from "./reviews-everywhere";
 // const BASE_URL = "http://localhost:3000";
 // if extension, then use hosted version
 // should be set by env / build process
-
-const BASE_URL =
-  "https://6e9d-2600-1700-5b24-a090-dcd4-affe-ad06-55fd.ngrok-free.app";
 
 async function loadReviews() {
   const reviewsResponse = await fetch(`${BASE_URL}/reviews`);

--- a/src/reviews-everywhere.js
+++ b/src/reviews-everywhere.js
@@ -1,10 +1,7 @@
 import van from "vanjs-core";
 
+import { BASE_URL } from "./api-client.js";
 import { CreateReviewForm, Overlay } from "./review.js";
-
-// TODO: Share base URL
-const BASE_URL =
-  "https://6e9d-2600-1700-5b24-a090-dcd4-affe-ad06-55fd.ngrok-free.app";
 
 /**
  * @param {MouseEvent} event
@@ -34,9 +31,9 @@ export function onDocumentClick(event) {
 
       const thisForm = e.currentTarget;
       const formInput = new FormData(thisForm);
-      console.log(formInput);
 
-      const createReviewRequest = new Request(`${BASE_URL}/review`, {
+      const createReviewUrl = `${BASE_URL}/review`;
+      const createReviewRequest = new Request(createReviewUrl, {
         method: "POST",
         body: new URLSearchParams(formInput),
         headers: {


### PR DESCRIPTION
- Import our API's base URL as an env var exposed to the client-side (via Vite's `VITE_` prefixing), default to `localhost` for development.
  - In demo-review
  - In core module

- Note that `manifest.json` needs to have the base URL added manually in `README`