### PR TITLE
Map domains to reviews

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,4 +1,3 @@
-
 generator client {
   provider = "prisma-client-js"
 }
@@ -14,6 +13,9 @@ model Review {
   text String
 
   // Position
-  top String
+  top  String
   left String
+
+  // Source page
+  url String @default("")
 }

--- a/src/api.js
+++ b/src/api.js
@@ -53,7 +53,12 @@ api.post("/review", async (req, res) => {
   res.send(`Review created`);
 });
 
-function parseReviewUrl(href /*String*/) {
+/**
+ * @param {string}  href - The full source URL of a review (like `window.location.href`)
+ *
+ * @returns {string} The parsed URL that's saved onto the `Review`. Used as reference when loading onto page. Note, query parameters are ignored.
+ */
+function parseReviewUrl(href) {
   const url = new URL(href);
 
   // Example, joins 'https://origin.com' with '/pathname/just/path'

--- a/src/api.js
+++ b/src/api.js
@@ -15,9 +15,15 @@ api.use(express.static("static"));
 api.use(express.urlencoded({ extended: true }));
 
 api.get("/reviews", async (req, res) => {
-  console.log(req);
+  // TODO: Share this with POST handler below, will make it easier to set default URL
+  const windowUrl = new URL(req.query.windowHref);
+  const url = `${windowUrl.origin}${windowUrl.pathname}`;
   // All reviews when no parameters are passed into `findMany`
-  const reviews = await prisma.review.findMany();
+  const reviews = await prisma.review.findMany({
+    where: {
+      url,
+    },
+  });
 
   res.send(reviews);
 });

--- a/src/api.js
+++ b/src/api.js
@@ -15,9 +15,7 @@ api.use(express.static("static"));
 api.use(express.urlencoded({ extended: true }));
 
 api.get("/reviews", async (req, res) => {
-  // TODO: Share this with POST handler below, will make it easier to set default URL
-  const windowUrl = new URL(req.query.windowHref);
-  const url = `${windowUrl.origin}${windowUrl.pathname}`;
+  const url = parseReviewUrl(req.query.windowHref);
   // All reviews when no parameters are passed into `findMany`
   const reviews = await prisma.review.findMany({
     where: {
@@ -43,8 +41,7 @@ api.post("/review", async (req, res) => {
   // Parse href (full URL) from client so we only use `origin` and `pathname`.
   // We ignore query parameters right now, but still have them available.
   const { windowHref, ...reviewWithoutUrl } = createReviewRequestBody;
-  const windowUrl = new URL(windowHref);
-  const url = `${windowUrl.origin}${windowUrl.pathname}`;
+  const url = parseReviewUrl(windowHref);
 
   try {
     const review = await prisma.review.create({
@@ -55,5 +52,14 @@ api.post("/review", async (req, res) => {
   }
   res.send(`Review created`);
 });
+
+function parseReviewUrl(href /*String*/) {
+  const url = new URL(href);
+
+  // Example, joins 'https://origin.com' with '/pathname/just/path'
+  const reviewUrl = `${url.origin}${url.pathname}`;
+
+  return reviewUrl;
+}
 
 export default api;

--- a/src/api.js
+++ b/src/api.js
@@ -8,27 +8,41 @@ const prisma = new PrismaClient();
 
 const api = express();
 
+// TODO: Get this file to reload the project on change
 api.use(express.static("static"));
 
 // Use middleware to parse URL-encoded form data
 api.use(express.urlencoded({ extended: true }));
 
 api.get("/reviews", async (req, res) => {
+  console.log(req);
   // All reviews when no parameters are passed into `findMany`
   const reviews = await prisma.review.findMany();
 
   res.send(reviews);
 });
+
+// We need to have the review tied to a domain when it's created.
+// Then when we fetch reviews, it'll be by domain? Or should they be IDs?
+// For now, we'll go with domains!
+//
+// And handle when there's no domain? Could migrate to like a dev URL?
+
 // TODO: Thinking it should be reviews? Maybe not? What if we post multiple? Eh.. not likely?
 api.post("/review", async (req, res) => {
   // TODO: Add typing with JSDoc
-  const reviewFromClient = req.body;
+  const createReviewRequestBody = req.body;
+  console.log("Create review", createReviewRequestBody);
 
-  console.log("Create review", reviewFromClient);
+  // Parse href (full URL) from client so we only use `origin` and `pathname`.
+  // We ignore query parameters right now, but still have them available.
+  const { windowHref, ...reviewWithoutUrl } = createReviewRequestBody;
+  const windowUrl = new URL(windowHref);
+  const url = `${windowUrl.origin}${windowUrl.pathname}`;
 
   try {
     const review = await prisma.review.create({
-      data: reviewFromClient,
+      data: { ...reviewWithoutUrl, url },
     });
   } catch (e) {
     console.error(e);

--- a/src/api.js
+++ b/src/api.js
@@ -26,12 +26,6 @@ api.get("/reviews", async (req, res) => {
   res.send(reviews);
 });
 
-// We need to have the review tied to a domain when it's created.
-// Then when we fetch reviews, it'll be by domain? Or should they be IDs?
-// For now, we'll go with domains!
-//
-// And handle when there's no domain? Could migrate to like a dev URL?
-
 // TODO: Thinking it should be reviews? Maybe not? What if we post multiple? Eh.. not likely?
 api.post("/review", async (req, res) => {
   // TODO: Add typing with JSDoc

--- a/src/demo-reviews.js
+++ b/src/demo-reviews.js
@@ -11,7 +11,9 @@ import { onDocumentClick } from "./reviews-everywhere";
 // should be set by env / build process
 
 async function loadReviews() {
-  const reviewsResponse = await fetch(`${BASE_URL}/reviews`);
+  const getReviewsRequest = new URL(`${BASE_URL}/reviews`);
+
+  const reviewsResponse = await fetch(getReviewsRequest);
 
   if (reviewsResponse.ok) {
     const reviews = await reviewsResponse.json();

--- a/src/demo-reviews.js
+++ b/src/demo-reviews.js
@@ -12,6 +12,8 @@ import { onDocumentClick } from "./reviews-everywhere";
 
 async function loadReviews() {
   const getReviewsRequest = new URL(`${BASE_URL}/reviews`);
+  // TODO: Share this parsing window location properties functionality with core
+  getReviewsRequest.searchParams.append("windowHref", window.location.href);
 
   const reviewsResponse = await fetch(getReviewsRequest);
 

--- a/src/demo-reviews.js
+++ b/src/demo-reviews.js
@@ -12,7 +12,8 @@ import { onDocumentClick } from "./reviews-everywhere";
 
 async function loadReviews() {
   const getReviewsRequest = new URL(`${BASE_URL}/reviews`);
-  // TODO: Share this parsing window location properties functionality with core
+
+  // Filter reviews that were created on this page
   getReviewsRequest.searchParams.append("windowHref", window.location.href);
 
   const reviewsResponse = await fetch(getReviewsRequest);

--- a/src/reviews-everywhere.js
+++ b/src/reviews-everywhere.js
@@ -33,11 +33,8 @@ export function onDocumentClick(event) {
       const formInput = new FormData(thisForm);
       const createReviewSearchParams = new URLSearchParams(formInput);
 
-      // Add current webpage URL to payload (without query parameters, ignored for now)
-      createReviewSearchParams.set(
-        "url",
-        `${window.location.origin}${window.location.pathname}`,
-      );
+      // Add current webpage URL to payload, parsed on backend for origin + pathname (ignore query params)
+      createReviewSearchParams.set("windowHref", window.location.href);
 
       const createReviewUrl = `${BASE_URL}/review`;
       const createReviewRequest = new Request(createReviewUrl, {

--- a/src/reviews-everywhere.js
+++ b/src/reviews-everywhere.js
@@ -31,11 +31,18 @@ export function onDocumentClick(event) {
 
       const thisForm = e.currentTarget;
       const formInput = new FormData(thisForm);
+      const createReviewSearchParams = new URLSearchParams(formInput);
+
+      // Add current webpage URL to payload (without query parameters, ignored for now)
+      createReviewSearchParams.set(
+        "url",
+        `${window.location.origin}${window.location.pathname}`,
+      );
 
       const createReviewUrl = `${BASE_URL}/review`;
       const createReviewRequest = new Request(createReviewUrl, {
         method: "POST",
-        body: new URLSearchParams(formInput),
+        body: createReviewSearchParams,
         headers: {
           // TODO: Test if this is added automatically?
           // Our server doesn't know how to parse `multipart/form-data`, so use simpler format


### PR DESCRIPTION
Reviews, comments, and any message will be mapped to a URL. For now, we ignore query parameters and only map messages to the origin + domain, like `'https://origin.com' + '/pathname/just/path'`.

- Add `url` to `Review` model
- Send `window.location.href` as `windowHref` query parameter when creating review
- Parse `windowHref` to ignore query parameters and save that as `url` on new review
- Receive `windowHref` when fetch reviews, parse, and filter reviews by that