### PR TITLE
Save href on review

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -50,7 +50,7 @@ api.post("/review", async (req, res) => {
  *
  * @returns {string} The parsed URL that's saved onto the `Review`. Used as reference when loading onto page. Note, query parameters are ignored.
  */
-function parseReviewUrl(href) {
+function _parseReviewUrl(href) {
   const url = new URL(href);
 
   // Example, joins 'https://origin.com' with '/pathname/just/path'

--- a/src/api.js
+++ b/src/api.js
@@ -14,12 +14,11 @@ api.use(express.static("static"));
 api.use(express.urlencoded({ extended: true }));
 
 api.get("/reviews", async (req, res) => {
-  // TODO: we should save this whooooooole thingggg, ya digg
-  const url = parseReviewUrl(req.query.windowHref);
+  // TODO: Do something with reviews that have no URL
   // All reviews when no parameters are passed into `findMany`
   const reviews = await prisma.review.findMany({
     where: {
-      url,
+      url: req.query.windowHref,
     },
   });
 
@@ -32,14 +31,13 @@ api.post("/review", async (req, res) => {
   const createReviewRequestBody = req.body;
   console.log("Create review", createReviewRequestBody);
 
-  // Parse href (full URL) from client so we only use `origin` and `pathname`.
-  // We ignore query parameters right now, but still have them available.
+  // Rename `windowHref` to `url` on Review
   const { windowHref, ...reviewWithoutUrl } = createReviewRequestBody;
-  const url = parseReviewUrl(windowHref);
+  const incomingReview = { url: windowHref, ...reviewWithoutUrl };
 
   try {
     const review = await prisma.review.create({
-      data: { ...reviewWithoutUrl, url },
+      data: incomingReview,
     });
   } catch (e) {
     console.error(e);

--- a/src/api.js
+++ b/src/api.js
@@ -13,11 +13,12 @@ api.use(express.static("static"));
 // Use middleware to parse URL-encoded form data
 api.use(express.urlencoded({ extended: true }));
 
+// TODO: Do something with reviews that have no URL
 api.get("/reviews", async (req, res) => {
-  // TODO: Do something with reviews that have no URL
   // All reviews when no parameters are passed into `findMany`
   const reviews = await prisma.review.findMany({
     where: {
+      // TODO: Do we ignore query parameters? Right now it's the most strict matching'
       url: req.query.windowHref,
     },
   });

--- a/src/api.js
+++ b/src/api.js
@@ -14,6 +14,7 @@ api.use(express.static("static"));
 api.use(express.urlencoded({ extended: true }));
 
 api.get("/reviews", async (req, res) => {
+  // TODO: we should save this whooooooole thingggg, ya digg
   const url = parseReviewUrl(req.query.windowHref);
   // All reviews when no parameters are passed into `findMany`
   const reviews = await prisma.review.findMany({

--- a/src/review.js
+++ b/src/review.js
@@ -31,6 +31,7 @@ export function Overlay({ children, id, position }) {
 
   const overlay = div({ class: "overlay-review" }, children);
 
+  // TODO: When is it missing? Get rid of this..
   if (id) {
     overlay.id = id;
   }


### PR DESCRIPTION
We should save all of the data from the source page, query parameters and everything. For now, we filter by the URL exactly.

- Save entire `windowHref` on Review (as `url`)
- Query entire `windowHref` (in `GET /reviews`)