### PR TITLE
Allow user to disable review menu on click

### DIFF
--- a/src/demo-reviews.js
+++ b/src/demo-reviews.js
@@ -50,7 +50,3 @@ van.add(
   document.body,
   SettingsMenu({ children: "Settings menu - Toggle context menu on click" }),
 );
-
-// TODO: Remove this event handler when the user disables it
-// Stop create review context menu from appearing on click
-// document.removeEventListener("click", onDocumentClick);

--- a/src/demo-reviews.js
+++ b/src/demo-reviews.js
@@ -1,7 +1,7 @@
 import van from "vanjs-core";
 
 import { BASE_URL } from "./api-client";
-import { OverlayReview } from "./review";
+import { OverlayReview, SettingsMenu } from "./review";
 import { onDocumentClick } from "./reviews-everywhere";
 
 // todo; FROM ENV
@@ -44,6 +44,12 @@ console.log("Context menu will appear on click - Reviews Everywhere");
 
 // TODO: Move this into another file, process, build?? IDK??
 document.addEventListener("click", onDocumentClick);
+
+// Add extension settings menu
+van.add(
+  document.body,
+  SettingsMenu({ children: "Settings menu - Toggle context menu on click" }),
+);
 
 // TODO: Remove this event handler when the user disables it
 // Stop create review context menu from appearing on click

--- a/src/demo-reviews.js
+++ b/src/demo-reviews.js
@@ -44,3 +44,7 @@ console.log("Context menu will appear on click - Reviews Everywhere");
 
 // TODO: Move this into another file, process, build?? IDK??
 document.addEventListener("click", onDocumentClick);
+
+// TODO: Remove this event handler when the user disables it
+// Stop create review context menu from appearing on click
+// document.removeEventListener("click", onDocumentClick);

--- a/src/demo-reviews.js
+++ b/src/demo-reviews.js
@@ -46,7 +46,4 @@ console.log("Context menu will appear on click - Reviews Everywhere");
 document.addEventListener("click", onDocumentClick);
 
 // Add extension settings menu
-van.add(
-  document.body,
-  SettingsMenu({ children: "Settings menu - Toggle context menu on click" }),
-);
+van.add(document.body, SettingsMenu());

--- a/src/review.js
+++ b/src/review.js
@@ -1,11 +1,20 @@
 import van from "vanjs-core";
 
+import { onDocumentClick } from "./reviews-everywhere";
+
 // TODO: Move this to another module? Eh.. maybe when this file gets to like 300+ lines?
 export function SettingsMenu({ children, id, position }) {
   const { input, div } = van.tags;
 
+  // TODO: Handle checked / unchecked
   const onchange = (e) => {
-    console.log("toggleCreateReviewMenuOnClickInput onchange!");
+    console.log(
+      "toggleCreateReviewMenuOnClickInput onchange!: onDocumentClick:",
+      onDocumentClick,
+    );
+
+    // Stop create review context menu from appearing on click
+    document.removeEventListener("click", onDocumentClick);
   };
   const toggleCreateReviewMenuOnClickInput = input({
     type: "checkbox",

--- a/src/review.js
+++ b/src/review.js
@@ -1,5 +1,13 @@
 import van from "vanjs-core";
 
+export function SettingsMenu({ children, id, position }) {
+  const { div } = van.tags;
+
+  const settingsMenu = div({}, children);
+
+  return settingsMenu;
+}
+
 /**
  *
  * @param {OverlayReviewProps} props

--- a/src/review.js
+++ b/src/review.js
@@ -1,9 +1,17 @@
 import van from "vanjs-core";
 
+// TODO: Move this to another module? Eh.. maybe when this file gets to like 300+ lines?
 export function SettingsMenu({ children, id, position }) {
   const { input, div } = van.tags;
 
-  const toggleCreateReviewMenuOnClickInput = input({ type: "checkbox" });
+  const onchange = (e) => {
+    console.log("toggleCreateReviewMenuOnClickInput onchange!");
+  };
+  const toggleCreateReviewMenuOnClickInput = input({
+    type: "checkbox",
+    onchange,
+  });
+
   const settingsMenu = div({}, toggleCreateReviewMenuOnClickInput);
 
   return settingsMenu;

--- a/src/review.js
+++ b/src/review.js
@@ -6,22 +6,22 @@ import { onDocumentClick, removeReviewMenu } from "./reviews-everywhere";
 export function SettingsMenu({ children, id, position }) {
   const { input, div } = van.tags;
 
-  const onchange = (e) => {
-    const showReviewMenuOnClick = e.target.checked;
-
-    if (showReviewMenuOnClick) {
-      document.addEventListener("click", onDocumentClick);
-    } else {
-      // Stop create review context menu from appearing on click
-      document.removeEventListener("click", onDocumentClick);
-
-      // Assume the user wants to hide the Review Menu
-      removeReviewMenu();
-    }
-  };
   const toggleReviewMenuOnClickInput = input({
     type: "checkbox",
-    onchange,
+
+    onchange: (e) => {
+      const showReviewMenuOnClick = e.target.checked;
+
+      if (showReviewMenuOnClick) {
+        document.addEventListener("click", onDocumentClick);
+      } else {
+        // Stop create review context menu from appearing on click
+        document.removeEventListener("click", onDocumentClick);
+
+        // Assume the user wants to hide the Review Menu
+        removeReviewMenu();
+      }
+    },
   });
 
   const settingsMenu = div({}, toggleReviewMenuOnClickInput);

--- a/src/review.js
+++ b/src/review.js
@@ -3,7 +3,7 @@ import van from "vanjs-core";
 import { onDocumentClick, removeReviewMenu } from "./reviews-everywhere";
 
 // TODO: Move this to another module? Eh.. maybe when this file gets to like 300+ lines?
-export function SettingsMenu({ children, id, position }) {
+export function SettingsMenu() {
   const { input, div } = van.tags;
 
   const toggleReviewMenuOnClickInput = input({

--- a/src/review.js
+++ b/src/review.js
@@ -6,15 +6,8 @@ import { onDocumentClick, removeReviewMenu } from "./reviews-everywhere";
 export function SettingsMenu({ children, id, position }) {
   const { input, div } = van.tags;
 
-  // TODO: Handle checked / unchecked
   const onchange = (e) => {
     const showReviewMenuOnClick = e.target.checked;
-
-    console.log("toggleCreateReviewMenuOnClickInput onchange: e:", e);
-    console.log(
-      "toggleCreateReviewMenuOnClickInput onchange: showReviewMenuOnClick:",
-      showReviewMenuOnClick,
-    );
 
     if (showReviewMenuOnClick) {
       document.addEventListener("click", onDocumentClick);
@@ -26,12 +19,12 @@ export function SettingsMenu({ children, id, position }) {
       removeReviewMenu();
     }
   };
-  const toggleCreateReviewMenuOnClickInput = input({
+  const toggleReviewMenuOnClickInput = input({
     type: "checkbox",
     onchange,
   });
 
-  const settingsMenu = div({}, toggleCreateReviewMenuOnClickInput);
+  const settingsMenu = div({}, toggleReviewMenuOnClickInput);
 
   return settingsMenu;
 }

--- a/src/review.js
+++ b/src/review.js
@@ -1,6 +1,6 @@
 import van from "vanjs-core";
 
-import { onDocumentClick } from "./reviews-everywhere";
+import { onDocumentClick, removeReviewMenu } from "./reviews-everywhere";
 
 // TODO: Move this to another module? Eh.. maybe when this file gets to like 300+ lines?
 export function SettingsMenu({ children, id, position }) {
@@ -22,12 +22,8 @@ export function SettingsMenu({ children, id, position }) {
       // Stop create review context menu from appearing on click
       document.removeEventListener("click", onDocumentClick);
 
-      // TODO: Share with module
-      const reviewMenuInDOM = document.querySelector("#add-review-overlay");
-
-      if (reviewMenuInDOM) {
-        reviewMenuInDOM.remove();
-      }
+      // Assume the user wants to hide the Review Menu
+      removeReviewMenu();
     }
   };
   const toggleCreateReviewMenuOnClickInput = input({

--- a/src/review.js
+++ b/src/review.js
@@ -17,7 +17,7 @@ export function SettingsMenu({ children, id, position }) {
     );
 
     if (showReviewMenuOnClick) {
-      // TODO: Re-enable showing review menu on click
+      document.addEventListener("click", onDocumentClick);
     } else {
       // Stop create review context menu from appearing on click
       document.removeEventListener("click", onDocumentClick);

--- a/src/review.js
+++ b/src/review.js
@@ -1,9 +1,10 @@
 import van from "vanjs-core";
 
 export function SettingsMenu({ children, id, position }) {
-  const { div } = van.tags;
+  const { input, div } = van.tags;
 
-  const settingsMenu = div({}, children);
+  const toggleCreateReviewMenuOnClickInput = input({ type: "checkbox" });
+  const settingsMenu = div({}, toggleCreateReviewMenuOnClickInput);
 
   return settingsMenu;
 }

--- a/src/review.js
+++ b/src/review.js
@@ -22,7 +22,12 @@ export function SettingsMenu({ children, id, position }) {
       // Stop create review context menu from appearing on click
       document.removeEventListener("click", onDocumentClick);
 
-      // TODO: Hide review menu if still open
+      // TODO: Share with module
+      const reviewMenuInDOM = document.querySelector("#add-review-overlay");
+
+      if (reviewMenuInDOM) {
+        reviewMenuInDOM.remove();
+      }
     }
   };
   const toggleCreateReviewMenuOnClickInput = input({

--- a/src/review.js
+++ b/src/review.js
@@ -3,8 +3,9 @@ import van from "vanjs-core";
 import { onDocumentClick, removeReviewMenu } from "./reviews-everywhere";
 
 // TODO: Move this to another module? Eh.. maybe when this file gets to like 300+ lines?
+//  Could export from reviews-everywhere since uses both imports?
 export function SettingsMenu() {
-  const { input, div } = van.tags;
+  const { input, label } = van.tags;
 
   const toggleReviewMenuOnClickInput = input({
     type: "checkbox",
@@ -24,7 +25,10 @@ export function SettingsMenu() {
     },
   });
 
-  const settingsMenu = div({}, toggleReviewMenuOnClickInput);
+  const settingsMenu = label(
+    toggleReviewMenuOnClickInput,
+    "Open review menu on click",
+  );
 
   return settingsMenu;
 }

--- a/src/review.js
+++ b/src/review.js
@@ -8,13 +8,22 @@ export function SettingsMenu({ children, id, position }) {
 
   // TODO: Handle checked / unchecked
   const onchange = (e) => {
+    const showReviewMenuOnClick = e.target.checked;
+
+    console.log("toggleCreateReviewMenuOnClickInput onchange: e:", e);
     console.log(
-      "toggleCreateReviewMenuOnClickInput onchange!: onDocumentClick:",
-      onDocumentClick,
+      "toggleCreateReviewMenuOnClickInput onchange: showReviewMenuOnClick:",
+      showReviewMenuOnClick,
     );
 
-    // Stop create review context menu from appearing on click
-    document.removeEventListener("click", onDocumentClick);
+    if (showReviewMenuOnClick) {
+      // TODO: Re-enable showing review menu on click
+    } else {
+      // Stop create review context menu from appearing on click
+      document.removeEventListener("click", onDocumentClick);
+
+      // TODO: Hide review menu if still open
+    }
   };
   const toggleCreateReviewMenuOnClickInput = input({
     type: "checkbox",

--- a/src/reviews-everywhere.js
+++ b/src/reviews-everywhere.js
@@ -8,11 +8,9 @@ import { CreateReviewForm, Overlay } from "./review.js";
  * @todo - Should we use PointerEvent? Seems like Firefox / Safari still use MouseEvents?
  */
 export function onDocumentClick(event) {
-  const addReviewMenuInDOM = document.querySelector("#add-review-overlay");
+  // Does nothing when missing from DOM
+  removeReviewMenu();
 
-  if (addReviewMenuInDOM) {
-    addReviewMenuInDOM.remove();
-  }
   // TODO: Add units prop so there's no string concatenation needed?
   const position = { top: `${event.clientY}px`, left: `${event.clientX}px` };
 
@@ -60,6 +58,14 @@ export function onDocumentClick(event) {
   });
 
   van.add(document.body, overlayReviewMenu);
+}
+
+export function removeReviewMenu() {
+  const reviewMenuInDOM = document.querySelector("#add-review-overlay");
+
+  if (reviewMenuInDOM) {
+    reviewMenuInDOM.remove();
+  }
 }
 
 const stopPropagationOnClick = (event) => event.stopPropagation();


### PR DESCRIPTION
## Overview
- Add settings menu
  - Checkbox labeled "Open review menu on click"
- Add checkbox onchange
  - If checked, add document on click handler to show review menu
  - If not checked, remove the handler and the review menu from the DOM
  
## Notes
This isn't that useful because the set value for on click handler isn't persisted across pages, or refreshes. This means it'll need to be disabled too frequently. We need a way to save the state in a way that's supported by the dev preview and the extension.