### PR TITLE
Save review menu on click enabled in extension storage

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -15,6 +15,7 @@
   ],
 
   "permissions": [
+    "storage",
     "https://282e-2600-1700-5b24-a090-211f-4802-68b7-33a5.ngrok-free.app/*"
   ]
 }

--- a/src/demo-reviews.js
+++ b/src/demo-reviews.js
@@ -45,5 +45,8 @@ console.log("Context menu will appear on click - Reviews Everywhere");
 // TODO: Move this into another file, process, build?? IDK??
 document.addEventListener("click", onDocumentClick);
 
+console.log("Fetching user settings from extension local storage");
+browser.storage.local.get().then(console.log).catch(console.error);
+
 // Add extension settings menu
 van.add(document.body, SettingsMenu());

--- a/src/demo-reviews.js
+++ b/src/demo-reviews.js
@@ -42,9 +42,6 @@ loadReviews().then(console.log).catch(console.error);
 
 console.log("Context menu will appear on click - Reviews Everywhere");
 
-// TODO: Move this into another file, process, build?? IDK??
-document.addEventListener("click", onDocumentClick);
-
 browser.storage.local
   .get()
   .then((storedKeys) => {
@@ -55,6 +52,10 @@ browser.storage.local
 
     const shouldOpenReviewMenuOnClick =
       storedKeys.shouldOpenReviewMenuOnClick ?? true;
+
+    if (shouldOpenReviewMenuOnClick) {
+      document.addEventListener("click", onDocumentClick);
+    }
 
     // Add extension settings menu with previously saved state (or defaults)
     van.add(document.body, SettingsMenu({ shouldOpenReviewMenuOnClick }));

--- a/src/demo-reviews.js
+++ b/src/demo-reviews.js
@@ -40,8 +40,7 @@ async function loadReviews() {
 
 loadReviews().then(console.log).catch(console.error);
 
-console.log("Context menu will appear on click - Reviews Everywhere");
-
+//
 browser.storage.local
   .get()
   .then((storedKeys) => {
@@ -55,6 +54,8 @@ browser.storage.local
 
     if (shouldOpenReviewMenuOnClick) {
       document.addEventListener("click", onDocumentClick);
+
+      console.log("Review menu will open on click - Reviews Everywhere");
     }
 
     // Add extension settings menu with previously saved state (or defaults)

--- a/src/demo-reviews.js
+++ b/src/demo-reviews.js
@@ -45,8 +45,18 @@ console.log("Context menu will appear on click - Reviews Everywhere");
 // TODO: Move this into another file, process, build?? IDK??
 document.addEventListener("click", onDocumentClick);
 
-console.log("Fetching user settings from extension local storage");
-browser.storage.local.get().then(console.log).catch(console.error);
+browser.storage.local
+  .get()
+  .then((storedKeys) => {
+    console.log(
+      "User settings from extension local storage retrieved",
+      storedKeys,
+    );
 
-// Add extension settings menu
-van.add(document.body, SettingsMenu());
+    const shouldOpenReviewMenuOnClick =
+      storedKeys.shouldOpenReviewMenuOnClick ?? true;
+
+    // Add extension settings menu with previously saved state (or defaults)
+    van.add(document.body, SettingsMenu({ shouldOpenReviewMenuOnClick }));
+  })
+  .catch(console.error);

--- a/src/demo-reviews.js
+++ b/src/demo-reviews.js
@@ -40,6 +40,8 @@ async function loadReviews() {
 
 loadReviews().then(console.log).catch(console.error);
 
+// TODO: Only use this when we know it's being used in the Firefox extension. Separate builds attempt?
+
 // Load user settings that are stored in extension's local storage.
 // Note, not exactly like a web page's local storage (`window.localStorage`)
 browser.storage.local

--- a/src/demo-reviews.js
+++ b/src/demo-reviews.js
@@ -40,7 +40,8 @@ async function loadReviews() {
 
 loadReviews().then(console.log).catch(console.error);
 
-//
+// Load user settings that are stored in extension's local storage.
+// Note, not exactly like a web page's local storage (`window.localStorage`)
 browser.storage.local
   .get()
   .then((storedKeys) => {

--- a/src/review.js
+++ b/src/review.js
@@ -4,11 +4,17 @@ import { onDocumentClick, removeReviewMenu } from "./reviews-everywhere";
 
 // TODO: Move this to another module? Eh.. maybe when this file gets to like 300+ lines?
 //  Could export from reviews-everywhere since uses both imports?
-export function SettingsMenu() {
+/**
+ *
+ * @param {{ shouldOpenReviewMenuOnClick: boolean }} props
+ */
+export function SettingsMenu(props) {
   const { input, label } = van.tags;
 
   const toggleReviewMenuOnClickInput = input({
     type: "checkbox",
+
+    checked: props.shouldOpenReviewMenuOnClick,
 
     onchange: (e) => {
       const shouldOpenReviewMenuOnClick = e.target.checked;

--- a/src/review.js
+++ b/src/review.js
@@ -11,12 +11,12 @@ export function SettingsMenu() {
     type: "checkbox",
 
     onchange: (e) => {
-      const doesOpenReviewMenuOnClick = e.target.checked;
+      const shouldOpenReviewMenuOnClick = e.target.checked;
 
       // TODO: Abstract so this works for extension and browser page
-      browser.storage.local.set({ doesOpenReviewMenuOnClick });
+      browser.storage.local.set({ shouldOpenReviewMenuOnClick });
 
-      if (doesOpenReviewMenuOnClick) {
+      if (shouldOpenReviewMenuOnClick) {
         document.addEventListener("click", onDocumentClick);
       } else {
         // Stop create review context menu from appearing on click

--- a/src/review.js
+++ b/src/review.js
@@ -11,9 +11,12 @@ export function SettingsMenu() {
     type: "checkbox",
 
     onchange: (e) => {
-      const showReviewMenuOnClick = e.target.checked;
+      const doesOpenReviewMenuOnClick = e.target.checked;
 
-      if (showReviewMenuOnClick) {
+      // TODO: Abstract so this works for extension and browser page
+      browser.storage.local.set({ doesOpenReviewMenuOnClick });
+
+      if (doesOpenReviewMenuOnClick) {
         document.addEventListener("click", onDocumentClick);
       } else {
         // Stop create review context menu from appearing on click


### PR DESCRIPTION
## Background
Save "should open Review menu" boolean state in extension locally so persistent across pages and refreshes

## Overview
- Add `"storage"` permission to `manifest.json`
  - Grants access to the extension's local storage (`browser.storage.local`)
- Get extension's local storage values (object with key / value pairs)
  - If `shouldOpenReviewMenuOnClick` is `true`, add "open Review menu" on document click handler
  - If missing, defaults to `true`
- Add `shouldOpenReviewMenuOnClick` to `SettingsMenu` to set initial `checked` state