### PR TITLE
Show reviews setting

### DIFF
--- a/src/demo-reviews.js
+++ b/src/demo-reviews.js
@@ -59,6 +59,11 @@ console.log("shouldShowReviews", shouldShowReviews);
 if (shouldOpenReviewMenuOnClick) {
   document.addEventListener("click", onDocumentClick);
 }
+
+if (!shouldShowReviews) {
+  document.querySelector("html").classList.add("hide-reviews-everywhere");
+}
+
 // TODO: Setters for each setting?
 function setSettings({ shouldOpenReviewMenuOnClick, shouldShowReviews }) {
   // Explicitly check for undefined because false is a valid value

--- a/src/demo-reviews.js
+++ b/src/demo-reviews.js
@@ -1,7 +1,7 @@
 import van from "vanjs-core";
 
 import { BASE_URL } from "./api-client";
-import { OverlayReview, SettingsMenu } from "./review";
+import { OverlayReview, SettingsMenu, hideReviews } from "./review";
 import { onDocumentClick } from "./reviews-everywhere";
 
 // todo; FROM ENV
@@ -61,7 +61,7 @@ if (shouldOpenReviewMenuOnClick) {
 }
 
 if (!shouldShowReviews) {
-  document.querySelector("html").classList.add("hide-reviews-everywhere");
+  hideReviews();
 }
 
 // TODO: Setters for each setting?

--- a/src/demo-reviews.js
+++ b/src/demo-reviews.js
@@ -48,20 +48,24 @@ loadReviews(BASE_URL).then(console.log).catch(console.error);
 
 // Load the setting from storage
 const openReviewMenuOnClickFromStorage = localStorage.getItem("shouldOpenReviewMenuOnClick") ?? "true";
+const shouldShowReviewsFromStorage = localStorage.getItem("shouldShowReviews") ?? "true";
 
 const shouldOpenReviewMenuOnClick = openReviewMenuOnClickFromStorage === "true";
+const shouldShowReviews = shouldShowReviewsFromStorage === "true";
 
 console.log("shouldOpenReviewMenuOnClick", shouldOpenReviewMenuOnClick);
+console.log("shouldShowReviews", shouldShowReviews);
 
 if (shouldOpenReviewMenuOnClick) {
   document.addEventListener("click", onDocumentClick);
 }
-
-function setSettings({ shouldOpenReviewMenuOnClick }) {
+// TODO: Figure out state so I don't reset these to `undefined` when toggling individual settings
+function setSettings({ shouldOpenReviewMenuOnClick, shouldShowReviews }) {
   localStorage.setItem("shouldOpenReviewMenuOnClick", shouldOpenReviewMenuOnClick);
+  localStorage.setItem("shouldShowReviews", shouldShowReviews);
 
-  console.log("Settings saved in local storage", { shouldOpenReviewMenuOnClick });
+  console.log("Settings saved in local storage", { shouldOpenReviewMenuOnClick, shouldShowReviews });
 }
 
 // Add extension settings menu with previously saved state (or defaults)
-van.add(document.body, SettingsMenu({ shouldOpenReviewMenuOnClick, setSettings }));
+van.add(document.body, SettingsMenu({ shouldOpenReviewMenuOnClick, shouldShowReviews, setSettings }));

--- a/src/demo-reviews.js
+++ b/src/demo-reviews.js
@@ -59,10 +59,17 @@ console.log("shouldShowReviews", shouldShowReviews);
 if (shouldOpenReviewMenuOnClick) {
   document.addEventListener("click", onDocumentClick);
 }
-// TODO: Figure out state so I don't reset these to `undefined` when toggling individual settings
+// TODO: Setters for each setting?
 function setSettings({ shouldOpenReviewMenuOnClick, shouldShowReviews }) {
-  localStorage.setItem("shouldOpenReviewMenuOnClick", shouldOpenReviewMenuOnClick);
-  localStorage.setItem("shouldShowReviews", shouldShowReviews);
+  // Explicitly check for undefined because false is a valid value
+
+  if(shouldOpenReviewMenuOnClick !== undefined) {
+    localStorage.setItem("shouldOpenReviewMenuOnClick", shouldOpenReviewMenuOnClick);
+  }
+
+  if(shouldShowReviews !== undefined) {
+    localStorage.setItem("shouldShowReviews", shouldShowReviews);
+  }
 
   console.log("Settings saved in local storage", { shouldOpenReviewMenuOnClick, shouldShowReviews });
 }

--- a/src/review.js
+++ b/src/review.js
@@ -103,13 +103,13 @@ export function Review({ review }) {
   const reviewText = p({ textContent: review.text });
   const reviewStars = ReviewStars(review);
 
-  return div({}, reviewText, reviewStars);
+  return div({ class: "review" }, reviewText, reviewStars);
 }
 
 export function Overlay({ children, id, position }) {
   const { div } = van.tags;
 
-  const overlay = div({ class: "overlay-review" }, children);
+  const overlay = div({ class: "overlay" }, children);
 
   // TODO: When is it missing? Get rid of this..
   if (id) {

--- a/src/review.js
+++ b/src/review.js
@@ -52,7 +52,7 @@ export function SettingsMenu(props) {
       if (shouldShowReviews) {
         document.querySelector("html").classList.remove("hide-reviews-everywhere");
       } else {
-        document.querySelector("html").classList.add("hide-reviews-everywhere");
+        hideReviews();
       }
     },
   });
@@ -74,6 +74,10 @@ export function SettingsMenu(props) {
   );
 
   return settingsMenu;
+}
+
+export function hideReviews() {
+  document.querySelector("html").classList.add("hide-reviews-everywhere");
 }
 
 /**

--- a/src/review.js
+++ b/src/review.js
@@ -35,9 +35,38 @@ export function SettingsMenu(props) {
     },
   });
 
-  const settingsMenu = label(
+  const toggleShowReviewsInput = input({
+    type: "checkbox",
+
+    checked: props.shouldShowReviews,
+
+    onchange: (e) => {
+      const shouldShowReviews = e.target.checked;
+
+      props.setSettings({ shouldShowReviews });
+
+      if (shouldShowReviews) {
+        console.log("Show reviews");
+      } else {
+
+      }
+    },
+  });
+
+  const toggleReviewMenuOnClickInputWithLabel = label(
     toggleReviewMenuOnClickInput,
     "Open review menu on click",
+  );
+
+  const toggleShowReviewsInputWithLabel = label(
+    toggleShowReviewsInput,
+    "Show reviews",
+  );
+
+  const settingsMenu = van.tags.div(
+    { class: "re-settings-menu" },
+    toggleReviewMenuOnClickInputWithLabel,
+    toggleShowReviewsInputWithLabel,
   );
 
   return settingsMenu;

--- a/src/review.js
+++ b/src/review.js
@@ -67,7 +67,7 @@ export function SettingsMenu(props) {
     "Show reviews",
   );
 
-  const settingsMenu = van.tags.div(
+  const settingsMenu = van.tags.form(
     { class: "re-settings-menu" },
     toggleReviewMenuOnClickInputWithLabel,
     toggleShowReviewsInputWithLabel,

--- a/src/review.js
+++ b/src/review.js
@@ -50,9 +50,9 @@ export function SettingsMenu(props) {
       props.setSettings({ shouldShowReviews });
 
       if (shouldShowReviews) {
-        console.log("Show reviews");
+        document.querySelector("html").classList.remove("hide-reviews-everywhere");
       } else {
-
+        document.querySelector("html").classList.add("hide-reviews-everywhere");
       }
     },
   });

--- a/src/review.js
+++ b/src/review.js
@@ -7,7 +7,11 @@ import { onDocumentClick, removeReviewMenu } from "./reviews-everywhere";
 // TODO: Define `settings` param type as object, or specific keys
 /**
  *
- * @param {{ shouldOpenReviewMenuOnClick: boolean, setSettings(settings) => void  }} props
+ * @param {{
+ *  shouldOpenReviewMenuOnClick: boolean,
+ *  shouldShowReviews: boolean
+ *  setSettings(settings) => void
+ * }} props
  */
 export function SettingsMenu(props) {
   const { input, label } = van.tags;

--- a/src/style.css
+++ b/src/style.css
@@ -9,3 +9,8 @@
   height: 1rem;
   width: 1rem;
 }
+
+/* Attach to `<html>` to hide all reviews */
+.hide-reviews-everywhere .overlay-review {
+  visibility: hidden;
+}

--- a/src/style.css
+++ b/src/style.css
@@ -1,7 +1,9 @@
-.overlay-review {
+.overlay {
   position: absolute;
   z-index: 99;
+}
 
+.review {
   background-color: white;
 }
 
@@ -11,6 +13,6 @@
 }
 
 /* Attach to `<html>` to hide all reviews */
-.hide-reviews-everywhere .overlay-review {
+.hide-reviews-everywhere .overlay .review {
   visibility: hidden;
 }


### PR DESCRIPTION
- Load `shouldShowReviews` from local storage
- Set setting in local storage if value provided is NOT `undefined`, ensures setting one value doesn't reset others to `undefined`
- Split `.overlay-review` into `.overlay` and `.review` CSS classes so Add Review input stays shown when reviews are hidden (since shares the `Overlay` Van JS component)
- Add "Show Reviews" input
  - Use local storage value or default for initial value
  - Show or hide reviews based on checked value
- Add `hide-reviews-everywhere` CSS class which hides `.overlay-review` elements within it
- Hide reviews on demo load (via `hideReviews` to share how it's done)