### PR TITLE
Timeline reviews

### DIFF
--- a/prisma/migrations/20241205091958_add_created_at_timestamp_that_defaults_to_now/migration.sql
+++ b/prisma/migrations/20241205091958_add_created_at_timestamp_that_defaults_to_now/migration.sql
@@ -1,0 +1,16 @@
+-- RedefineTables
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_Review" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "text" TEXT NOT NULL,
+    "stars" INTEGER,
+    "top" TEXT NOT NULL,
+    "left" TEXT NOT NULL,
+    "url" TEXT NOT NULL DEFAULT ''
+);
+INSERT INTO "new_Review" ("id", "left", "stars", "text", "top", "url") SELECT "id", "left", "stars", "text", "top", "url" FROM "Review";
+DROP TABLE "Review";
+ALTER TABLE "new_Review" RENAME TO "Review";
+PRAGMA foreign_key_check;
+PRAGMA foreign_keys=ON;

--- a/prisma/migrations/20241205093152_add_type_to_review_with_overlay_default/migration.sql
+++ b/prisma/migrations/20241205093152_add_type_to_review_with_overlay_default/migration.sql
@@ -1,0 +1,17 @@
+-- RedefineTables
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_Review" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "text" TEXT NOT NULL,
+    "stars" INTEGER,
+    "top" TEXT NOT NULL,
+    "left" TEXT NOT NULL,
+    "url" TEXT NOT NULL DEFAULT '',
+    "type" TEXT NOT NULL DEFAULT 'overlay'
+);
+INSERT INTO "new_Review" ("createdAt", "id", "left", "stars", "text", "top", "url") SELECT "createdAt", "id", "left", "stars", "text", "top", "url" FROM "Review";
+DROP TABLE "Review";
+ALTER TABLE "new_Review" RENAME TO "Review";
+PRAGMA foreign_key_check;
+PRAGMA foreign_keys=ON;

--- a/prisma/migrations/20241209083740_remove_overlay_default_from_review/migration.sql
+++ b/prisma/migrations/20241209083740_remove_overlay_default_from_review/migration.sql
@@ -1,0 +1,17 @@
+-- RedefineTables
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_Review" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "text" TEXT NOT NULL,
+    "stars" INTEGER,
+    "top" TEXT NOT NULL,
+    "left" TEXT NOT NULL,
+    "url" TEXT NOT NULL DEFAULT '',
+    "type" TEXT NOT NULL
+);
+INSERT INTO "new_Review" ("createdAt", "id", "left", "stars", "text", "top", "type", "url") SELECT "createdAt", "id", "left", "stars", "text", "top", "type", "url" FROM "Review";
+DROP TABLE "Review";
+ALTER TABLE "new_Review" RENAME TO "Review";
+PRAGMA foreign_key_check;
+PRAGMA foreign_keys=ON;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -22,7 +22,6 @@ model Review {
   url String @default("")
 
   // TODO: Use enum? Last job said it was a bad idea..
-  // TODO: Remove default? Doesn't make sense, user will always set it. Kinda did it to migrate the DB..
   // Determines how it's displayed
-  type String @default("overlay")
+  type String
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -9,6 +9,7 @@ datasource db {
 
 model Review {
   id Int @id @default(autoincrement())
+  createdAt DateTime @default(now())
 
   text String
   stars Int?

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -20,4 +20,9 @@ model Review {
 
   // Source page
   url String @default("")
+
+  // TODO: Use enum? Last job said it was a bad idea..
+  // TODO: Remove default? Doesn't make sense, user will always set it. Kinda did it to migrate the DB..
+  // Determines how it's displayed
+  type String @default("overlay")
 }

--- a/src/api.js
+++ b/src/api.js
@@ -40,6 +40,15 @@ api.post("/review", async (req, res) => {
   // Empty string means no stars were set, so use `null` instead of `0` (may support 0 stars in the future?)
   const stars = incomingReview.stars === "" ? null : Number(incomingReview.stars);
 
+  // Review type validation
+  const reviewTypes = ['overlay', 'timeline'];
+
+  console.assert(reviewTypes.includes(createReviewRequestBody.type), `Invalid review type, must be ${reviewTypes}`);
+
+  if(!reviewTypes.includes(createReviewRequestBody.type)) {
+    throw new Error(`Invalid review type: ${createReviewRequestBody.type}`);
+  }
+
   try {
     const review = await prisma.review.create({
       data: { ...incomingReview, stars },

--- a/src/demo-reviews.js
+++ b/src/demo-reviews.js
@@ -1,7 +1,7 @@
 import van from "vanjs-core";
 
 import { BASE_URL } from "./api-client";
-import { CreateReviewForm, OverlayReview, SettingsMenu, hideReviews } from "./review";
+import { CreateReviewForm, OverlayReview, Review, SettingsMenu, hideReviews } from "./review";
 import { onDocumentClick, stopPropagationOnClick } from "./reviews-everywhere";
 
 // todo; FROM ENV
@@ -124,7 +124,7 @@ const timelineReviewForm = CreateReviewForm({
       if(review.type === "timeline") {
         console.log("Adding review to timeline");
 
-        van.add(document.body, van.tags.p(review.message, review.createdAt));
+        van.add(document.body, Review({ review }));
       }
       // const overlayReview = OverlayReview({
       //   review,

--- a/src/demo-reviews.js
+++ b/src/demo-reviews.js
@@ -116,11 +116,16 @@ const timelineReviewForm = CreateReviewForm({
     const createReviewResponse = await fetch(createReviewRequest);
 
     if (createReviewResponse.ok) {
-      // Hide the Review Menu to show the new review
-      // removeReviewMenu();
+      // TODO: Type using what Prisma provides
+      const review = await createReviewResponse.json();
+      console.log("Create review success", review);
 
-      // TODO: Add to sidebar when timeline review is created
-      // const review = await createReviewResponse.json();
+      // TODO: Somewhat unnecessary we _could_ know this from the beginning (API for just timeline reviews?)
+      if(review.type === "timeline") {
+        console.log("Adding review to timeline");
+
+        van.add(document.body, van.tags.p(review.message, review.createdAt));
+      }
       // const overlayReview = OverlayReview({
       //   review,
       //   position: { left: review.left, top: review.top },

--- a/src/demo-reviews.js
+++ b/src/demo-reviews.js
@@ -4,11 +4,10 @@ import { BASE_URL } from "./api-client";
 import { CreateReviewForm, OverlayReview, Review, SettingsMenu, hideReviews } from "./review";
 import { onDocumentClick, stopPropagationOnClick } from "./reviews-everywhere";
 
-// todo; FROM ENV
-// if dev, then use localhost, like in local page
-// const BASE_URL = "http://localhost:3000";
-// if extension, then use hosted version
-// should be set by env / build process
+// Timeline Reviews feed, reviews are populated on fetch and post
+const timelineReviewsFeed = van.tags.div({ class: "timeline-reviews-feed" }, "Timeline reviews feed");
+
+van.add(document.body, timelineReviewsFeed);
 
 /**
  * @param {string} baseURL - The base URL of the API
@@ -24,7 +23,14 @@ async function loadReviews(baseURL) {
   const reviewsResponse = await fetch(getReviewsRequest);
 
   if (reviewsResponse.ok) {
+    // TODO: Type using what Prisma provides
     const reviews = await reviewsResponse.json();
+
+    const timelineReviews = reviews.filter((review) => review.type === "timeline").map((review) => Review({ review }));
+    console.log("Timeline reviews", timelineReviews);
+    // Show them to the user. Note, tried to use `.forEach(timelineReviewsFeed.appendChild)`, but it didn't work..
+    timelineReviews.forEach((timelineReview) => timelineReviewsFeed.appendChild(timelineReview));
+
     // TODO: Add `.filter(r => r.type === 'overlay')` to only show overlay reviews?
     const overlayReviews = reviews.map((review) =>
       // This renders fine, but it's technically not a review.
@@ -82,9 +88,6 @@ function setSettings({ shouldOpenReviewMenuOnClick, shouldShowReviews }) {
 // Add extension settings menu with previously saved state (or defaults)
 van.add(document.body, SettingsMenu({ shouldOpenReviewMenuOnClick, shouldShowReviews, setSettings }));
 
-const timelineReviewsFeed = van.tags.div({ class: "timeline-reviews-feed" }, "Timeline reviews feed");
-
-van.add(document.body, timelineReviewsFeed);
 // TODO: Abstract the parts that are duplicated here and the document onclick handler
 // Timeline review form
 const createReviewUrl = `${BASE_URL}/review`;

--- a/src/demo-reviews.js
+++ b/src/demo-reviews.js
@@ -131,12 +131,6 @@ const timelineReviewForm = CreateReviewForm({
 
         timelineReviewsFeed.appendChild(Review({ review }));
       }
-      // const overlayReview = OverlayReview({
-      //   review,
-      //   position: { left: review.left, top: review.top },
-      // });
-
-      // van.add(document.body, overlayReview);
 
     } else {
       console.error("Failed to create review", createReviewResponse);

--- a/src/demo-reviews.js
+++ b/src/demo-reviews.js
@@ -82,6 +82,9 @@ function setSettings({ shouldOpenReviewMenuOnClick, shouldShowReviews }) {
 // Add extension settings menu with previously saved state (or defaults)
 van.add(document.body, SettingsMenu({ shouldOpenReviewMenuOnClick, shouldShowReviews, setSettings }));
 
+const timelineReviewsFeed = van.tags.div({ class: "timeline-reviews-feed" }, "Timeline reviews feed");
+
+van.add(document.body, timelineReviewsFeed);
 // TODO: Abstract the parts that are duplicated here and the document onclick handler
 // Timeline review form
 const createReviewUrl = `${BASE_URL}/review`;
@@ -124,7 +127,7 @@ const timelineReviewForm = CreateReviewForm({
       if(review.type === "timeline") {
         console.log("Adding review to timeline");
 
-        van.add(document.body, Review({ review }));
+        timelineReviewsFeed.appendChild(Review({ review }));
       }
       // const overlayReview = OverlayReview({
       //   review,

--- a/src/demo-reviews.js
+++ b/src/demo-reviews.js
@@ -31,8 +31,7 @@ async function loadReviews(baseURL) {
     // Show them to the user. Note, tried to use `.forEach(timelineReviewsFeed.appendChild)`, but it didn't work..
     timelineReviews.forEach((timelineReview) => timelineReviewsFeed.appendChild(timelineReview));
 
-    // TODO: Add `.filter(r => r.type === 'overlay')` to only show overlay reviews?
-    const overlayReviews = reviews.map((review) =>
+    const overlayReviews = reviews.filter(r => r.type === 'overlay').map((review) =>
       // This renders fine, but it's technically not a review.
       // There's no stars. TODO: Generalize to Message? OverlayMessage?
       OverlayReview({

--- a/src/review.js
+++ b/src/review.js
@@ -105,7 +105,7 @@ export function Review({ review }) {
   // Stars are optional, so only render if they exist
   const reviewStars = review.stars ? ReviewStars(review) : null;
 
-  return div({ class: "review" }, reviewText, reviewStars);
+  return div({ class: "review" }, reviewText, reviewStars, review.createdAt);
 }
 
 export function Overlay({ children, id, position }) {
@@ -128,6 +128,7 @@ export function Overlay({ children, id, position }) {
  * @typedef {Object} Review
  * @property {string} text - What the user had to say
  * @property {number} stars - Number of stars, out of 5
+ * @property {Date} createdAt - When the review was created
  */
 
 /**

--- a/src/review.js
+++ b/src/review.js
@@ -212,8 +212,10 @@ export function ReviewStars({ stars }) {
 
   return div({}, starsRendered);
 }
-
-export function CreateReviewForm({ action, onclick, onsubmit, position }) {
+// TODO: Evaluate if this is really easier than plaid ol' HTML
+// TODO: Need to enfore type being set
+// TODO: Add JSDoc type? Is it needed? VSCode might infer it, but it's buggy
+export function CreateReviewForm({ action, onclick, onsubmit, position, reviewType }) {
   const { button, form, input } = van.tags;
 
   const reviewTextInput = input({ name: "text" });
@@ -226,7 +228,7 @@ export function CreateReviewForm({ action, onclick, onsubmit, position }) {
     value: position.left,
   });
   // TODO: Use hidden input
-  const typeInput = input({ name: "type", type: "text", value: "" });
+  const typeInput = input({ name: "type", type: "text", value: reviewType });
 
   // This _did_ enable submit with Enter key after number input was added, but then failed again..
   // TODO: See if we can remove this (isn't fixed by number input being hidden)

--- a/src/review.js
+++ b/src/review.js
@@ -225,6 +225,9 @@ export function CreateReviewForm({ action, onclick, onsubmit, position }) {
     type: "hidden",
     value: position.left,
   });
+  // TODO: Use hidden input
+  const typeInput = input({ name: "type", type: "text", value: "" });
+
   // This _did_ enable submit with Enter key after number input was added, but then failed again..
   // TODO: See if we can remove this (isn't fixed by number input being hidden)
   const submitButton = button({ type: "submit", textContent: "Submit" });
@@ -246,6 +249,7 @@ export function CreateReviewForm({ action, onclick, onsubmit, position }) {
     numStarsInput,
     topInput,
     leftInput,
+    typeInput,
     submitButton
   );
 }

--- a/src/reviews-everywhere.js
+++ b/src/reviews-everywhere.js
@@ -23,8 +23,8 @@ export function onDocumentClick(event) {
     // Guess the action would only benefit when JS is disabled? Do extensions run in that case (different runtime?)?
     action: createReviewUrl,
 
-    // Learned that action uses: `Content-Type: application/x-www-form-urlencoded`
-    // While the fetch POST with formData uses `: multipart/form-data`
+    // Document click handler is creating the form, so it's an overlay Review (placed where clicked)
+    reviewType: "overlay",
 
     onsubmit: async (e) => {
       // Stop redirect caused by default submit

--- a/src/reviews-everywhere.js
+++ b/src/reviews-everywhere.js
@@ -86,4 +86,4 @@ export function removeReviewMenu() {
   }
 }
 
-const stopPropagationOnClick = (event) => event.stopPropagation();
+export const stopPropagationOnClick = (event) => event.stopPropagation();


### PR DESCRIPTION
# Changes
- Add `createdAt` timestamp to `Review` DB model
- Show `createdAt` in `Review` UI

- Add `type` to `Review` DB model
  - Use `overlay` or `timeline`
  - No default, always set by form

- Add `reviewType` as prop to `CreateReviewForm`
  - Sent in payload on submit
  - Overlay Create Review form sets it to `overlay`

- Add Timeline Review form (always shown)
  - Sets `reviewType` to `timeline`

- Show Timeline Reviews
  - Add Timeline Reviews Feed
  - Append Timeline Reviews fetched on load
  - Append reviews that were just created

- Validate `type` received from client

# Notes
This is a rough set of changes, but the minimal amount needed to show we can create and show them dynamically. I'll need to abstract the Create Review form to work easier in both cases (`overlay` or `timeline`), better typing, etc.