### PR TITLE
Sidebar timeline reviews feed

### DIFF
--- a/src/demo-reviews.js
+++ b/src/demo-reviews.js
@@ -9,6 +9,16 @@ const timelineReviewsFeed = van.tags.div({ class: "timeline-reviews-feed" }, "Ti
 
 van.add(document.body, timelineReviewsFeed);
 
+const toggleTimelineReviewsFeedButton = van.tags.button(
+  {
+    onclick: () => {
+      timelineReviewsFeed.classList.toggle("hidden");
+    },
+  },
+  "Toggle timeline reviews feed",
+);
+van.add(document.body, toggleTimelineReviewsFeedButton);
+
 /**
  * @param {string} baseURL - The base URL of the API
  */

--- a/src/style.css
+++ b/src/style.css
@@ -16,3 +16,9 @@
 .hide-reviews-everywhere .overlay .review {
   visibility: hidden;
 }
+
+.timeline-reviews-feed {
+  position: absolute;
+  top: 0;
+  right: 0;
+}

--- a/src/style.css
+++ b/src/style.css
@@ -22,3 +22,7 @@
   top: 0;
   right: 0;
 }
+
+.hidden {
+  visibility: hidden;
+}


### PR DESCRIPTION
# Changes
- Style Timeline Reviews Feed
  - Position absolute on top right side

- Add toggle feed button
  - Adds or removes 'hidden` class on click

# Notes
Puts the feed where it needs to go, but could be toggled nicer, like sliding in and out of view, but that's a nice-to-have.