### PR TITLE
format created at with LA timezone and simpler form

### DIFF
--- a/src/review.js
+++ b/src/review.js
@@ -105,7 +105,15 @@ export function Review({ review }) {
   // Stars are optional, so only render if they exist
   const reviewStars = review.stars ? ReviewStars(review) : null;
 
-  return div({ class: "review" }, reviewText, reviewStars, review.createdAt);
+  // TODO: When it's time to change any of these, abstract as a whole
+  const createdAtDate = new Date(review.createdAt);
+  const createdAt = new Intl.DateTimeFormat('en-US', {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+    timeZone: 'America/Los_Angeles',
+  }).format(createdAtDate);
+
+  return div({ class: "review" }, reviewText, reviewStars, createdAt);
 }
 
 export function Overlay({ children, id, position }) {


### PR DESCRIPTION
# Changes
Format `review.createdAt` using `Intl.DateTimeFormat`, `'en-US'`, other options, and `format`

# Note
Everything's hardcoded, and nothing's configurable, but that's okay because I'm the only one using it :)