### PR TITLE
Use manifest v3 and fetch reviews from background

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,5 +13,3 @@ npm run dev
 ```
 
 # Extension
-## Caveats
-Our API's base URL must be part of the `permissions` in `manifest.json`. However, we haven't mapped that to what's in `.env`, so must be updated manually.

--- a/README.md
+++ b/README.md
@@ -13,3 +13,5 @@ npm run dev
 ```
 
 # Extension
+## Caveats
+With Manifest V3, our content script can no longer make a request to our API. Instead, we now make the request from a background script, `extension-background.js`, and send the response data back in a `Message` (must be serializable). Unfortunately, the background script isn't built with Vite / Rollup since it's not an `input`, so we can't use imports. This is preventing us from importing the `BASE_URL` from `api-client.js`, which means it's hard-coded to the current ngrok URL and will need to be changed during development.

--- a/manifest.json
+++ b/manifest.json
@@ -9,6 +9,10 @@
     "default_title": "Messages Everywhere"
   },
 
+  "background": {
+    "scripts": ["src/extension-background.js"]
+  },
+
   "content_scripts": [
     {
       "matches": ["*://*/*"],

--- a/manifest.json
+++ b/manifest.json
@@ -1,21 +1,23 @@
 {
-  "manifest_version": 2,
+  "manifest_version": 3,
   "name": "Reviews Everywhere",
   "version": "0.0",
 
   "description": "Provides reviews to any website",
 
+  "action": {
+    "default_title": "Messages Everywhere"
+  },
+
   "content_scripts": [
     {
       "matches": ["*://*/*"],
-      "//": "TODO: Probably should be firefox-extension.js...",
       "js": ["dist/main.js"],
       "css": ["src/style.css"]
     }
   ],
 
   "permissions": [
-    "storage",
-    "https://282e-2600-1700-5b24-a090-211f-4802-68b7-33a5.ngrok-free.app/*"
+    "storage"
   ]
 }

--- a/manifest.json
+++ b/manifest.json
@@ -21,8 +21,6 @@
     }
   ],
 
-  "host_permissions": ["*://b73efe21c6c4.ngrok-free.app/*"],
-
   "permissions": [
     "storage"
   ]

--- a/manifest.json
+++ b/manifest.json
@@ -16,10 +16,12 @@
   "content_scripts": [
     {
       "matches": ["*://*/*"],
-      "js": ["dist/main.js"],
+      "js": ["dist/firefox-extension.js"],
       "css": ["src/style.css"]
     }
   ],
+
+  "host_permissions": ["*://b73efe21c6c4.ngrok-free.app/*"],
 
   "permissions": [
     "storage"

--- a/src/extension-background.js
+++ b/src/extension-background.js
@@ -1,3 +1,4 @@
+// TODO: Fix Uncaught SyntaxError: import declarations may only appear at top level of a module
 
 console.log("`extension-background.js` has ran!");
 
@@ -14,8 +15,15 @@ browser.runtime.onMessage.addListener((message, sender, sendResponse) => {
     console.log("Background script: sender:", sender)
 
     if (message.action === FETCH_MESSAGES_ACTION) {
-        console.log(`Background received ${FETCH_MESSAGES_ACTION} action`);
+        // console.log("Fetching reviews", { getReviewsRequest });
 
-        return true; // Indicates that sendResponse will be called asynchronously
+        // Don't seem to get the response object back..
+        // return fetch(getReviewsRequest);
+
+        sendResponse({ baseURL: BASE_URL, windowHref: sender.url });
     }
+
+    // This is needed to run an asynchronous task with `sendResponse` on both Firefox and Chrome
+    // https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/runtime/onMessage#sending_an_asynchronous_response_using_sendresponse
+    return true;
 });

--- a/src/extension-background.js
+++ b/src/extension-background.js
@@ -1,0 +1,2 @@
+
+console.log("`extension-background.js` has ran!");

--- a/src/extension-background.js
+++ b/src/extension-background.js
@@ -18,9 +18,13 @@ browser.runtime.onMessage.addListener((message, sender, sendResponse) => {
     if (message.action === FETCH_MESSAGES_ACTION) {
         console.log("Background: Fetching reviews");
 
-        // TODO: Add catch here, can we just throw in fetchReviews?
         fetchReviews({ windowHref: sender.url })
             .then(reviews => sendResponse({ reviews }))
+            .catch(error => {
+                // TODO: Better logging, this doesn't show the response attached in `fetchReviews`
+                console.error(error);
+                sendResponse({ success: false, error });
+            }); // Runs the success handler on other side, rather have error
 
         // NOTE: Using `return` with response Promise doesn't seem to send it to client listener (maybe because it can't be serialized, but no error shown)
     }
@@ -46,6 +50,9 @@ async function fetchReviews(options) {
         return reviews;
     }
 
-    // TODO: Attach response: reviewsResponse
-    throw Error("Reviews failed to fetch");
+    const fetchReviewsError = Error("Failed to fetch reviews");
+    // TODO: Better logging, this doesn't show when provided to `console.error`
+    fetchReviewsError.response = reviewsResponse;
+
+    throw fetchReviewsError;
 }

--- a/src/extension-background.js
+++ b/src/extension-background.js
@@ -15,31 +15,36 @@ browser.runtime.onMessage.addListener((message, sender, sendResponse) => {
     console.log("Background script: sender:", sender)
 
     if (message.action === FETCH_MESSAGES_ACTION) {
-        console.log(`Background received ${FETCH_MESSAGES_ACTION} action`);
-        const BASE_URL = "https://b73efe21c6c4.ngrok-free.app";
-        const getReviewsRequest = new URL(`${BASE_URL}/reviews`);
+        console.log("Background: Fetching reviews");
 
-        getReviewsRequest.searchParams.append("windowHref", sender.url);
+        // TODO: Add catch here, can we just throw in fetchReviews?
+        fetchReviews({ windowHref: sender.url })
+            .then(reviews => sendResponse({ reviews }))
 
-        console.log("Fetching reviews", { getReviewsRequest });
-
-        // Using `return` doesn't seem to get send the response object (maybe because it can't be serialized, but no error shown)
-        fetch(getReviewsRequest)
-            .then(res => {
-
-                if(res.ok) {
-                    console.log("Background: reviews fetched successfully");
-
-                    res.json().then(reviews => {
-                        console.log("Background: reviews as JSON", reviews);
-
-                        sendResponse({ reviews, windowHref: sender.url });
-                    })
-                }
-            });
+        // NOTE: Using `return` with response Promise doesn't seem to send it to client listener (maybe because it can't be serialized, but no error shown)
     }
 
     // This is needed to run an asynchronous task with `sendResponse` on both Firefox and Chrome
     // https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/runtime/onMessage#sending_an_asynchronous_response_using_sendresponse
     return true;
 });
+// TODO: Revisit pattern, don't like that error isn't handled and we're giving back null. Throw instead?
+async function fetchReviews(options) {
+    const BASE_URL = "https://b73efe21c6c4.ngrok-free.app";
+    const getReviewsRequest = new URL(`${BASE_URL}/reviews`);
+
+    getReviewsRequest.searchParams.append("windowHref", options.windowHref);
+
+    const reviewsResponse = await fetch(getReviewsRequest);
+
+    if (reviewsResponse.ok) {
+        console.log("Background: reviews fetched successfully");
+
+        const reviews = await reviewsResponse.json();
+
+        return reviews;
+    }
+
+    console.warn("Bad status when fetching reviews", reviewsResponse);
+    return null;
+}

--- a/src/extension-background.js
+++ b/src/extension-background.js
@@ -1,2 +1,12 @@
 
 console.log("`extension-background.js` has ran!");
+
+
+browser.runtime.onMessage.addListener((message, sender, sendResponse) => {
+
+  if (message.action === "fetchData") {
+    console.log("Background received fetchData message");
+
+    return true; // Indicates that sendResponse will be called asynchronously
+  }
+});

--- a/src/extension-background.js
+++ b/src/extension-background.js
@@ -3,10 +3,18 @@ console.log("`extension-background.js` has ran!");
 
 
 browser.runtime.onMessage.addListener((message, sender, sendResponse) => {
+    console.log("Background script: onMessage");
 
-  if (message.action === "fetchData") {
-    console.log("Background received fetchData message");
+    // Ignore messages from inactive tabs
+    if(!sender.tab.active) {
+        return;
+    }
 
-    return true; // Indicates that sendResponse will be called asynchronously
-  }
+    console.log("Background script: sender:", sender)
+
+    if (message.action === "fetchData") {
+        console.log("Background received fetchData message");
+
+        return true; // Indicates that sendResponse will be called asynchronously
+    }
 });

--- a/src/extension-background.js
+++ b/src/extension-background.js
@@ -19,6 +19,7 @@ browser.runtime.onMessage.addListener((message, sender, sendResponse) => {
         console.log("Background: Fetching reviews");
 
         fetchReviews({ windowHref: sender.url })
+            // TODO: Add types for messageResult: { success: true, data: T } | { success: false, error: Error }
             .then(reviews => {
                 console.log("Background: Reviews fetched successfully");
                 sendResponse({ success: true, reviews })
@@ -40,6 +41,7 @@ browser.runtime.onMessage.addListener((message, sender, sendResponse) => {
 });
 
 async function fetchReviews(options) {
+    // TODO: Have this come from `.env`, requires possibly two build inputs (which I've failed at before..)
     const BASE_URL = "https://b73efe21c6c4.ngrok-free.app";
     const getReviewsRequest = new URL(`${BASE_URL}/reviews`);
 

--- a/src/extension-background.js
+++ b/src/extension-background.js
@@ -21,8 +21,8 @@ browser.runtime.onMessage.addListener((message, sender, sendResponse) => {
         fetchReviews({ windowHref: sender.url })
             .then(reviews => sendResponse({ reviews }))
             .catch(error => {
-                // TODO: Better logging, this doesn't show the response attached in `fetchReviews`
-                console.error(error);
+                // Logging `error` only won't show response, `error.response` must be logged separately
+                console.error(error, error?.response);
                 sendResponse({ success: false, error });
             }); // Runs the success handler on other side, rather have error
 
@@ -33,7 +33,7 @@ browser.runtime.onMessage.addListener((message, sender, sendResponse) => {
     // https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/runtime/onMessage#sending_an_asynchronous_response_using_sendresponse
     return true;
 });
-// TODO: Revisit pattern, don't like that error isn't handled and we're giving back null. Throw instead?
+
 async function fetchReviews(options) {
     const BASE_URL = "https://b73efe21c6c4.ngrok-free.app";
     const getReviewsRequest = new URL(`${BASE_URL}/reviews`);
@@ -51,8 +51,13 @@ async function fetchReviews(options) {
     }
 
     const fetchReviewsError = Error("Failed to fetch reviews");
-    // TODO: Better logging, this doesn't show when provided to `console.error`
-    fetchReviewsError.response = reviewsResponse;
+
+    // Create copy of values so they're enumerable, meaning they can be logged
+    fetchReviewsError.response = {
+        status: reviewsResponse.status,
+        statusText: reviewsResponse.statusText,
+        url: reviewsResponse.url
+    };
 
     throw fetchReviewsError;
 }

--- a/src/extension-background.js
+++ b/src/extension-background.js
@@ -54,13 +54,7 @@ async function fetchReviews(options) {
     }
 
     const fetchReviewsError = Error("Failed to fetch reviews");
-
-    // Create copy of values so they're enumerable, meaning they can be logged
-    fetchReviewsError.response = {
-        status: reviewsResponse.status,
-        statusText: reviewsResponse.statusText,
-        url: reviewsResponse.url
-    };
+    fetchReviewsError.response = reviewsResponse;
 
     throw fetchReviewsError;
 }

--- a/src/extension-background.js
+++ b/src/extension-background.js
@@ -15,12 +15,28 @@ browser.runtime.onMessage.addListener((message, sender, sendResponse) => {
     console.log("Background script: sender:", sender)
 
     if (message.action === FETCH_MESSAGES_ACTION) {
-        // console.log("Fetching reviews", { getReviewsRequest });
+        console.log(`Background received ${FETCH_MESSAGES_ACTION} action`);
+        const BASE_URL = "https://b73efe21c6c4.ngrok-free.app";
+        const getReviewsRequest = new URL(`${BASE_URL}/reviews`);
 
-        // Don't seem to get the response object back..
-        // return fetch(getReviewsRequest);
+        getReviewsRequest.searchParams.append("windowHref", sender.url);
 
-        sendResponse({ baseURL: BASE_URL, windowHref: sender.url });
+        console.log("Fetching reviews", { getReviewsRequest });
+
+        // Using `return` doesn't seem to get send the response object (maybe because it can't be serialized, but no error shown)
+        fetch(getReviewsRequest)
+            .then(res => {
+
+                if(res.ok) {
+                    console.log("Background: reviews fetched successfully");
+
+                    res.json().then(reviews => {
+                        console.log("Background: reviews as JSON", reviews);
+
+                        sendResponse({ reviews, windowHref: sender.url });
+                    })
+                }
+            });
     }
 
     // This is needed to run an asynchronous task with `sendResponse` on both Firefox and Chrome

--- a/src/extension-background.js
+++ b/src/extension-background.js
@@ -27,8 +27,9 @@ browser.runtime.onMessage.addListener((message, sender, sendResponse) => {
             .catch(error => {
                 // Logging `error` only won't show response, `error.response` must be logged separately
                 console.error(error, error?.response);
+                // Runs the success handler in content script (`firefox-extension.js`), but I'd rather have the error callback used..
                 sendResponse({ success: false, error });
-            }); // Runs the success handler on other side, rather have error
+            });
 
         // NOTE: Using `return` with response Promise doesn't seem to send it to client listener (maybe because it can't be serialized, but no error shown)
     }

--- a/src/extension-background.js
+++ b/src/extension-background.js
@@ -1,6 +1,7 @@
 
 console.log("`extension-background.js` has ran!");
 
+const FETCH_MESSAGES_ACTION = "fetchMessages"
 
 browser.runtime.onMessage.addListener((message, sender, sendResponse) => {
     console.log("Background script: onMessage");
@@ -12,8 +13,8 @@ browser.runtime.onMessage.addListener((message, sender, sendResponse) => {
 
     console.log("Background script: sender:", sender)
 
-    if (message.action === "fetchData") {
-        console.log("Background received fetchData message");
+    if (message.action === FETCH_MESSAGES_ACTION) {
+        console.log(`Background received ${FETCH_MESSAGES_ACTION} action`);
 
         return true; // Indicates that sendResponse will be called asynchronously
     }

--- a/src/extension-background.js
+++ b/src/extension-background.js
@@ -46,6 +46,6 @@ async function fetchReviews(options) {
         return reviews;
     }
 
-    console.warn("Bad status when fetching reviews", reviewsResponse);
-    return null;
+    // TODO: Attach response: reviewsResponse
+    throw Error("Reviews failed to fetch");
 }

--- a/src/extension-background.js
+++ b/src/extension-background.js
@@ -2,6 +2,7 @@
 
 console.log("`extension-background.js` has ran!");
 
+// TODO: Think of new name for general "message" posted on a webpage to distuingish from extension messages (and others since so generic). postIt? placement?
 const FETCH_MESSAGES_ACTION = "fetchMessages"
 
 browser.runtime.onMessage.addListener((message, sender, sendResponse) => {

--- a/src/extension-background.js
+++ b/src/extension-background.js
@@ -19,7 +19,8 @@ browser.runtime.onMessage.addListener((message, sender, sendResponse) => {
         console.log("Background: Fetching reviews");
 
         fetchReviews({ windowHref: sender.url })
-            .then(reviews => sendResponse({ reviews }))
+            .then(reviews => sendResponse({ success: true, reviews }))
+
             .catch(error => {
                 // Logging `error` only won't show response, `error.response` must be logged separately
                 console.error(error, error?.response);

--- a/src/extension-background.js
+++ b/src/extension-background.js
@@ -19,7 +19,10 @@ browser.runtime.onMessage.addListener((message, sender, sendResponse) => {
         console.log("Background: Fetching reviews");
 
         fetchReviews({ windowHref: sender.url })
-            .then(reviews => sendResponse({ success: true, reviews }))
+            .then(reviews => {
+                console.log("Background: Reviews fetched successfully");
+                sendResponse({ success: true, reviews })
+            })
 
             .catch(error => {
                 // Logging `error` only won't show response, `error.response` must be logged separately
@@ -44,8 +47,6 @@ async function fetchReviews(options) {
     const reviewsResponse = await fetch(getReviewsRequest);
 
     if (reviewsResponse.ok) {
-        console.log("Background: reviews fetched successfully");
-
         const reviews = await reviewsResponse.json();
 
         return reviews;

--- a/src/firefox-extension.js
+++ b/src/firefox-extension.js
@@ -1,5 +1,4 @@
-import { onDocumentClick } from "./reviews-everywhere.js";
 
-document.addEventListener("click", onDocumentClick);
-
-console.log("Reviews Everywhere - LOADED");
+browser.runtime.sendMessage({ action: "fetchData", url: "https://api.example.com/data" }, (response) => {
+  console.log("Content script: response from background", response);
+});

--- a/src/firefox-extension.js
+++ b/src/firefox-extension.js
@@ -1,6 +1,13 @@
+import { onDocumentClick } from "./reviews-everywhere.js";
 import { renderReviews } from "./review";
 
 
+// TODO: Fix creating reviews, needs to happen in the background script (like the fetch below)
+// Show 'Create Review' form on click
+document.addEventListener("click", onDocumentClick);
+
+
+// Ask background script to fetch Reviews / Messages
 const sending = browser.runtime.sendMessage({
     action: "fetchMessages",
 });

--- a/src/firefox-extension.js
+++ b/src/firefox-extension.js
@@ -6,8 +6,16 @@ const sending = browser.runtime.sendMessage({
     action: "fetchMessages",
 });
 
-sending.then(renderReviews, console.error);
+sending.then(handleFetchReviewsMessage, console.error);
 
+function handleFetchReviewsMessage(fetchReviewsResult) {
+
+    if(fetchReviewsResult.success) {
+        renderReviews(fetchReviewsResult);
+    }
+
+    console.error("Background failed to respond to fetchMessages action", fetchReviewsResult.error);
+}
 
 function renderReviews({ reviews }) {
     const overlayReviews = reviews

--- a/src/firefox-extension.js
+++ b/src/firefox-extension.js
@@ -1,6 +1,25 @@
+import van from "vanjs-core";
+
+import { OverlayReview } from "./review";
 
 const sending = browser.runtime.sendMessage({
     action: "fetchMessages",
 });
 
-sending.then(console.log, console.error);
+sending.then(renderReviews, console.error);
+
+
+function renderReviews({ reviews }) {
+    const overlayReviews = reviews
+        .filter(r => r.type === 'overlay')
+        .map((review) =>
+            OverlayReview({
+                review,
+                position: { left: review.left, top: review.top },
+            }),
+    );
+    // Show them to the user
+    overlayReviews.forEach((overlayReview) =>
+      van.add(document.body, overlayReview),
+    );
+}

--- a/src/firefox-extension.js
+++ b/src/firefox-extension.js
@@ -1,4 +1,4 @@
 
-browser.runtime.sendMessage({ action: "fetchData", url: "https://api.example.com/data" }, (response) => {
+browser.runtime.sendMessage({ action: "fetchMessages" }, (response) => {
   console.log("Content script: response from background", response);
 });

--- a/src/firefox-extension.js
+++ b/src/firefox-extension.js
@@ -1,4 +1,6 @@
 
-browser.runtime.sendMessage({ action: "fetchMessages" }, (response) => {
-  console.log("Content script: response from background", response);
+const sending = browser.runtime.sendMessage({
+    action: "fetchMessages",
 });
+
+sending.then(console.log, console.error);

--- a/src/firefox-extension.js
+++ b/src/firefox-extension.js
@@ -1,6 +1,5 @@
-import van from "vanjs-core";
+import { renderReviews } from "./review";
 
-import { OverlayReview } from "./review";
 
 const sending = browser.runtime.sendMessage({
     action: "fetchMessages",
@@ -15,19 +14,4 @@ function handleFetchReviewsMessage(fetchReviewsResult) {
     }
 
     console.error("Background failed to respond to fetchMessages action", fetchReviewsResult.error);
-}
-
-function renderReviews({ reviews }) {
-    const overlayReviews = reviews
-        .filter(r => r.type === 'overlay')
-        .map((review) =>
-            OverlayReview({
-                review,
-                position: { left: review.left, top: review.top },
-            }),
-    );
-    // Show them to the user
-    overlayReviews.forEach((overlayReview) =>
-      van.add(document.body, overlayReview),
-    );
 }

--- a/src/firefox-extension.js
+++ b/src/firefox-extension.js
@@ -19,6 +19,7 @@ function handleFetchReviewsMessage(fetchReviewsResult) {
     if(fetchReviewsResult.success) {
         renderReviews(fetchReviewsResult);
     }
-
-    console.error("Background failed to respond to fetchMessages action", fetchReviewsResult.error);
+    else {
+        console.error("Background failed to respond to fetchMessages action", fetchReviewsResult.error);
+    }
 }

--- a/src/review.js
+++ b/src/review.js
@@ -8,6 +8,9 @@ import { onDocumentClick, removeReviewMenu } from "./reviews-everywhere";
  * @property {string} text - What the user had to say
  * @property {number} stars - Number of stars, out of 5
  * @property {Date} createdAt - When the review was created
+ * @property {'overlay' | 'timeline'} type
+ * @property {Position['top']} top
+ * @property {Position['left']} left
  */
 
 /**
@@ -323,4 +326,24 @@ export function ReviewPreview(review) {
     // Note, state-derived child node ensures it re-renders on update
     Review({ review }),
   );
+}
+
+/**
+ *
+ * @param {{ reviews: Review[] }} options
+ * @returns
+ */
+export function renderReviews({ reviews }) {
+    const overlayReviews = reviews
+        .filter(r => r.type === 'overlay')
+        .map((review) =>
+            OverlayReview({
+                review,
+                position: { left: review.left, top: review.top },
+            }),
+    );
+    // Show them to the user
+    overlayReviews.forEach((overlayReview) =>
+      van.add(document.body, overlayReview),
+    );
 }

--- a/vite.config.js
+++ b/vite.config.js
@@ -7,7 +7,7 @@ export default defineConfig({
 
     rollupOptions: {
       // overwrite default .html entry
-      input: "/src/main.js",
+      input: "/src/firefox-extension.js",
 
       output: {
         // Removes hash from built file in `dist/`.


### PR DESCRIPTION
# Changes
- Use `"manifest_version": 3`
- Use `firefox-extension.js` as content script (instead of `main.js` which was more for preview / demo / playground)
- Add background script
  - Defined in `background.scripts: []` in `manifest.json`
  - Fetch reviews for `sender.url` (from message between content script and background)
  - Respond to content script with `success: boolean` and `reviews` on success
- Render reviews from content script

# Todos
- Fix creating reviews from webpages. Needs to happen in the background like the fetch for reviews.